### PR TITLE
Add agv controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ roslaunch agv_launch main_multi.launch
 ```bash
 roslaunch agv_follow_lane follow_lane.launch
 ```
+
+- AGV follow aruco:
+
+```bash
+roslaunch agv_follow_aruco follow_aruco.launch
+```
+
+- AGV controller:
+
+```bash
+roslaunch agv_control agv_control.launch
+```


### PR DESCRIPTION
This PR includes:
- Add agv control package
  - This package determines how agv will drive in gazebo world
  - The driving environment consists of a map of the following lane package and the following aruco model of the following aruco
- chore:Update readme about agv_control package
- hotfix: Fix aruco image with id 1